### PR TITLE
Transform.apply_to_list for inhomogeneous lists

### DIFF
--- a/hyperbolic/poincare/transform.py
+++ b/hyperbolic/poincare/transform.py
@@ -35,17 +35,17 @@ class Transform:
             raise ValueError('Invalid transform')
         return Ideal(math.atan2(y, x))
     def apply_to_list(self, points, verify=False):
-        if len(points) > 0:
-            if isinstance(points[0], Ideal):
+        def apply(pt):
+            if isinstance(pt, Ideal):
                 if verify:
-                    def f(p): return self.apply_to_ideal(p, verify=True)
+                    return self.apply_to_ideal(pt, verify=True)
                 else:
-                    f = self.apply_to_ideal
-            elif isinstance(points[0], Point):
-                f = self.apply_to_point
+                    return self.apply_to_ideal(pt)
+            elif isinstance(pt, Point):
+                return self.apply_to_point(pt)
             else:
-                f = self.apply_to_tuple
-        return [f(p) for p in points]
+                return self.apply_to_tuple(pt)
+        return [apply(p) for p in points]
     def apply_to_shape(self, shape):
         '''Transform a euclidean shape.
 


### PR DESCRIPTION
The current implementation of Transform.apply_to_list assumes its argument to consist entirely of ideal or non-ideal points. Therefore it cannot be applied to the fundamental domain of SL_2(Z), for instance. This change checks the type of each point in the argument individually.