### PR TITLE
Consistent action of conjugation

### DIFF
--- a/hyperbolic/poincare/transform.py
+++ b/hyperbolic/poincare/transform.py
@@ -95,13 +95,13 @@ class Transform:
     def merge(*transfoms):
         a,b,c,d = 1,0,0,1
         conj = False
-        for i, trans in enumerate(transfoms):
+        for trans in reversed(transfoms):
             a2,b2,c2,d2 = trans.abcd
             if trans.conj:
                 a,b,c,d = (a.conjugate(), b.conjugate(), c.conjugate(),
                         d.conjugate())
                 conj = not conj
-            a,b,c,d = a*a2+c*b2, b*a2+d*b2, a*c2+c*d2, b*c2+d*d2
+            a,b,c,d = a2*a+c2*b, b2*a+d2*b, a2*c+c2*d, b2*c+d2*d
         return Transform(a,b,c,d,conj=conj)
     @staticmethod
     def shift_origin(new_origin, new_x=None):


### PR DESCRIPTION
It should generally be true that

a.apply_to_point(b.apply_to_point(p)) == Transform.merge(a,b).apply_to_point(p)

(up to numerical error).

According to Transform.apply_to_tuple() a potential conjugation is first applied before the matrix is multiplied. Since the action is from the left this means that conjugation is on the right.

Thus in Transform.merge() conjugation has to be applied to the entries of the product of the factors to the right not to the left (see issue #24). This commit fixes this.