### PR TITLE
Transform: det and normalized.

### DIFF
--- a/hyperbolic/poincare/transform.py
+++ b/hyperbolic/poincare/transform.py
@@ -88,6 +88,14 @@ class Transform:
         a, b, c, d = self.abcd
         return Transform(a.conjugate(), b.conjugate(),
                          c.conjugate(), d.conjugate(), conj=not self.conj)
+    def det(self):
+        a,b,c,d = self.abcd
+        return a*d - b*c
+    def normalized(self):
+        a,b,c,d = self.abcd
+        n = cmath.sqrt(self.det())
+        return Transform(a/n, b/n, c/n, d/n)
+
     @staticmethod
     def identity():
         return Transform(1,0,0,1,1)


### PR DESCRIPTION
Adds methods `det()` and `normalized()` to `Transform`. These are mostly for convenience. For instance it is hard to tell whether to two `Transform`s are the same transformation since they may differ by a complex scalar. Note that the normalized version is not technically normalized as two normalized `Transforms` describing the same transformation may differ by sign (but only by sign).